### PR TITLE
Make url to rabbit.tech absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rabbit r1 source code [part 1]
 
-[rabbit.tech](rabbit.tech) has been making waves with its highly publicized release of the Rabbit R1 device, claiming it can perform tasks on your behalf and liberate you from app-based interactions. But let's call a spade a spade – **this is a blatant lie**. And we're about to expose it with the first partial release of the source code for its so-called "large action model".
+[rabbit.tech](https://rabbit.tech) has been making waves with its highly publicized release of the Rabbit R1 device, claiming it can perform tasks on your behalf and liberate you from app-based interactions. But let's call a spade a spade – **this is a blatant lie**. And we're about to expose it with the first partial release of the source code for its so-called "large action model".
 
 For those with a technical background, it's painfully clear that there's **no artificial intelligence or large action model in sight**. In reality, they're simply relying on several **Playwright** automation scripts to do the job for you, which is why they only support four apps: Spotify, Midjourney, Doordash, and UberEats.
  


### PR DESCRIPTION
Bare url like `rabbit.tech` are interpreted as relative url by github in rendered markdown. That's no good. Well it's good if you want to put a logo or a banner in your readme. Adding a protocol make the url absolute and fix the issue